### PR TITLE
display .expando-button unobtrusively at far right

### DIFF
--- a/reddit-no-frills.css
+++ b/reddit-no-frills.css
@@ -348,7 +348,7 @@ a {
 }
 
 .expando-button {
-  display: none;
+  float: right;
 }
 
 /*
@@ -576,10 +576,6 @@ table#srList {
 }
 
 /* POSTS */
-.expando-button {
-  display: none !important;
-}
-
 .NERPageMarker {
   background-color: #F2F2F2 !important;
 }


### PR DESCRIPTION
The current layout of timestamp, author, and comments links is retained.

Far right placement is also ideal when collapsing expando ("X" button).